### PR TITLE
Next major version. 3?  2.001?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
 language: perl
 perl:
-  - "5.24"
-  - "5.22"
-  - "5.20"
-  - "5.18"
-  - "5.16"
-  - "5.14"
-  - "5.12"
-  - "5.10"
-  - "5.8"
+  - '5.10'
+  - '5.12'
+  - '5.14'
+  - '5.16'
+  - '5.18'
+  - '5.20'
+  - '5.22'
+addons:
+   postgresql: "9.3"
 env:
-  - RELEASE_TESTING: 1
+  - DB_TESTING=1 COVERAGE=1 RELEASE_TESTING=1
+before_install:
+   - eval $(curl https://travis-perl.github.io/init) --auto
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ perl:
   - '5.18'
   - '5.20'
   - '5.22'
+  - '5.24'
 addons:
    postgresql: "9.3"
 env:

--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 Revision history for PGObject-Simple
 
+2.0	2017-05-19
+	Removed support for Perl 5.6 and 5.8
+	Code cleanup
+	Now provide exports for code re-use in rolls and adaptors
+	Give precedence to functions over hash elements in object mappings.
+
 1.9     2016-11-20
         Fix issue #5: Don't call $value->to_db() [PGObject already does]
         Fix issue #6: Don't special-case BYTEA arguments

--- a/Changes
+++ b/Changes
@@ -5,6 +5,8 @@ Revision history for PGObject-Simple
 	Code cleanup
 	Now provide exports for code re-use in rolls and adaptors
 	Give precedence to functions over hash elements in object mappings.
+	Added getters and setters for dbh
+	Added association interface
 
 1.9     2016-11-20
         Fix issue #5: Don't call $value->to_db() [PGObject already does]

--- a/Changes
+++ b/Changes
@@ -8,6 +8,7 @@ Revision history for PGObject-Simple
 	Added getters and setters for dbh
 	Added association interface
 	Added support for package-level reader/factories for param defaults
+	Added support for object accessors for param defaults
 
 2.0.0   2016-11-21
         Release version 2.0.0 in order to get out of the 1.9 vs 1.10 mess

--- a/Changes
+++ b/Changes
@@ -7,6 +7,7 @@ Revision history for PGObject-Simple
 	Give precedence to functions over hash elements in object mappings.
 	Added getters and setters for dbh
 	Added association interface
+	Added support for package-level reader/factories for param defaults
 
 2.0.0   2016-11-21
         Release version 2.0.0 in order to get out of the 1.9 vs 1.10 mess

--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Revision history for PGObject-Simple
 
-2.001	2017-05-19
+3.0	2017-05-19
 	Removed support for Perl 5.6 and 5.8
 	Code cleanup
 	Now provide exports for code re-use in rolls and adaptors

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -36,6 +36,8 @@
 ^tmp
 \bTAGS$
 ^MYMETA.yml$
+^.travis.yml$
+^MYMETA.json$
 
 \bSu-[\d\.\_]+
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,4 @@
-use 5.006;
+use 5.010;
 use strict;
 use warnings;
 use ExtUtils::MakeMaker;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,6 +17,7 @@ WriteMakefile(
     },
     BUILD_REQUIRES => {
         'Test::More' => 0,
+        'Data::Dumper' => 0,
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => 'PGObject-Simple-*' },

--- a/lib/PGObject/Simple.pm
+++ b/lib/PGObject/Simple.pm
@@ -276,6 +276,12 @@ sub call_dbmethod {
 
         $args{funcprefix} //= $self->{_func_prefix};
         $args{funcschema} //= $self->{_func_schema};
+    } elsif (!ref $self){
+        local $@;
+	# see if we have package-level reader/factories
+        $args{dbh} //= "$self"->dbh if eval {"$self"->dbh};
+        $args{funcschema} //= "$self"->func_schema if eval {"$self"->func_schema};
+        $args{funcprefix} //= "$self"->func_prefix if eval {"$self"->func_prefix};
     }
     $args{funcprefix} ||= '';
     my $info = PGObject->function_info(%args);
@@ -313,6 +319,12 @@ sub call_procedure {
         $args{registry} //= $self->{_registry};
 
         $args{dbh} = $self->dbh if $self->dbh and !$args{dbh};
+    } elsif (!ref $self){
+        local $@;
+	# see if we have package-level reader/factories
+        $args{dbh} //= "$self"->dbh if eval {"$self"->dbh};
+        $args{funcschema} //= "$self"->func_schema if eval {"$self"->func_schema};
+        $args{funcprefix} //= "$self"->func_prefix if eval {"$self"->func_prefix};
     }
     $args{funcprefix} ||= '';
 

--- a/lib/PGObject/Simple.pm
+++ b/lib/PGObject/Simple.pm
@@ -13,11 +13,11 @@ PGObject::Simple - Minimalist stored procedure mapper based on LedgerSMB's DBObj
 
 =head1 VERSION
 
-Version 2
+Version 2.1
 
 =cut
 
-our $VERSION = '2';
+our $VERSION = 2.001000;
 
 =head1 SYNOPSIS
 

--- a/lib/PGObject/Simple.pm
+++ b/lib/PGObject/Simple.pm
@@ -1,10 +1,11 @@
 package PGObject::Simple;
 
-use 5.006;
+use 5.010;
 use strict;
 use warnings;
 use Carp;
 use PGObject;
+use parent 'Exporter';
 
 =head1 NAME
 
@@ -12,12 +13,11 @@ PGObject::Simple - Minimalist stored procedure mapper based on LedgerSMB's DBObj
 
 =head1 VERSION
 
-Version 1.9
+Version 2
 
 =cut
 
-our $VERSION = '1.9';
-
+our $VERSION = '2';
 
 =head1 SYNOPSIS
 
@@ -59,6 +59,52 @@ To call a stored procedure with named arguments from a hashref with overrides.
       running_funcs => [{agg => 'sum(amount)', alias => 'total'}],
       args          => { id => undef }, # force to create new!
   );
+
+
+=head1 EXPORTS
+
+We now allow various calls to be exported.  We recommend using the tags.
+
+=head2 One-at-a-time Exports
+
+=over
+
+=item call_dbmethod
+
+=item call_procedure
+
+=item set_dbh
+
+=item _set_funcprefix
+
+=item _set_funcschema
+
+=item _set_registry
+
+=back
+
+=head2 Export Tags
+
+Below are the export tags listed including the leading ':' used to invoke them.
+
+=over
+
+=item :mapper
+	    call_dbmethod, call_procedure, and set_dbh
+
+=item :full
+	    All methods that can be exported at once.
+
+=back
+
+=cut
+
+our @EXPORT_OK = qw(call_dbmethod call_procedure set_dbh associate dbh
+                   _set_funcprefix
+                    _set_funcschema _set_registry);
+
+our %EXPORT_TAGS = (mapper => [qw(call_dbmethod call_procedure set_dbh dbh)],
+                    full => \@EXPORT_OK);
 
 =head1 DESCRIPTION
 
@@ -117,7 +163,29 @@ Sets the database handle (needs DBD::Pg 2.0 or later) to $dbh
 
 sub set_dbh {
     my ($self, $dbh) = @_;
-    $self->{_DBH} = $dbh;
+    $self->{_dbh} = $dbh;
+}
+
+=head2 dbh
+
+Returns the database handle for the object.
+
+=cut
+
+sub dbh {
+    my ($self) = @_;
+    return $self->{_dbh};
+}
+
+=head2 associate($pgobject)
+
+Sets the db handle to that from the $pgobject.
+
+=cut
+
+sub associate {
+    my ($self, $other) = @_;
+    $self->set_dbh($other->dbh);
 }
 
 =head2 _set_funcprefix
@@ -174,30 +242,41 @@ stored procedures should be prepared to handle these.
 As with call_procedure below, this returns a single hashref when called in a
 scalar context, and a list of hashrefs when called in a list context.
 
+NEW IN 2.0: We now give preference to functions of the same name over 
+properties.  So $obj->foo() will be used before $obj->{foo}.  This enables
+better data encapsulation.
+
 =cut
+
+sub _self_to_arg { # refactored from map call, purely internal
+    my ($self, $args, $argname) = @_;
+    my $db_arg;
+    $argname =~ s/^in_//;
+    local $@;
+    eval { $db_arg = $self->can($argname)->($self) } if ref $self and $argname;
+    $db_arg = $args->{args}->{$argname} if exists $args->{args}->{$argname};
+    $db_arg = $db_arg->to_db if eval {$db_arg->can('to_db')};
+    $db_arg = { type => 'bytea', value => $db_arg} if $_->{type} eq 'bytea';
+
+    return $db_arg;
+}
 
 sub call_dbmethod {
     my ($self) = shift @_;
     my %args = @_;
     croak 'No function name provided' unless $args{funcname};
     if (eval { $self->isa(__PACKAGE__) } and ref $self){
-        $args{dbh} = $self->{_DBH} if $self->{_DBH} and !$args{dbh};
+        $args{dbh} = $self->{_dbh} if $self->{_dbh} and !$args{dbh};
 
-        $args{funcprefix} = $self->{_func_prefix} if !defined $args{funcprefix};
-        $args{funcschema} = $self->{_func_schema} if !defined $args{funcschema};
+        $args{funcprefix} //= $self->{_func_prefix};
+        $args{funcschema} //= $self->{_func_schema};
     }
     $args{funcprefix} ||= '';
     my $info = PGObject->function_info(%args);
 
     my $arglist = [];
-    @{$arglist} = map {
-        my $argname = $_->{name};
-        my $db_arg;
-        $argname =~ s/^in_//;
-        $db_arg = $self->{$argname} if ref $self;
-        $db_arg = $args{args}->{$argname} if exists $args{args}->{$argname};
-        $db_arg;
-    } @{$info->{args}};
+    @{$arglist} = map { _self_to_arg($self, \%args, $_->{name}) } 
+                  @{$info->{args}};
     $args{args} = $arglist;
 
     # The conditional return is necessary since the object may carry a registry
@@ -223,9 +302,9 @@ sub call_procedure {
     my ($self) = shift @_;
     my %args = @_;
     if (eval { $self->isa(__PACKAGE__) } and ref $self ){
-        $args{funcprefix} = $self->{_func_prefix} if !defined $args{funcprefix};
-        $args{funcschema} = $self->{_func_schema} if !defined $args{funcschema};
-        $args{registry} = $self->{_registry} if !defined $args{registry};
+        $args{funcprefix} //= $self->{_func_prefix};
+        $args{funcschema} //= $self->{_func_schema};
+        $args{registry} //= $self->{_registry};
 
         $args{dbh} = $self->{_DBH} if $self->{_DBH} and !$args{dbh};
     }
@@ -334,7 +413,7 @@ L<http://search.cpan.org/dist/PGObject-Simple/>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2013-2016 Chris Travers.
+Copyright 2013-2017 Chris Travers.
 
 Redistribution and use in source and compiled forms with or without 
 modification, are permitted provided that the following conditions are met:

--- a/lib/PGObject/Simple.pm
+++ b/lib/PGObject/Simple.pm
@@ -306,7 +306,7 @@ sub call_procedure {
         $args{funcschema} //= $self->{_func_schema};
         $args{registry} //= $self->{_registry};
 
-        $args{dbh} = $self->{_DBH} if $self->{_DBH} and !$args{dbh};
+        $args{dbh} = $self->dbh if $self->dbh and !$args{dbh};
     }
     $args{funcprefix} ||= '';
 

--- a/lib/PGObject/Simple.pm
+++ b/lib/PGObject/Simple.pm
@@ -13,11 +13,11 @@ PGObject::Simple - Minimalist stored procedure mapper based on LedgerSMB's DBObj
 
 =head1 VERSION
 
-Version 2.1
+Version 3
 
 =cut
 
-our $VERSION = 2.001000;
+our $VERSION = 3;
 
 =head1 SYNOPSIS
 

--- a/lib/PGObject/Simple.pm
+++ b/lib/PGObject/Simple.pm
@@ -253,7 +253,13 @@ sub _self_to_arg { # refactored from map call, purely internal
     my $db_arg;
     $argname =~ s/^in_//;
     local $@;
-    eval { $db_arg = $self->can($argname)->($self) } if ref $self and $argname;
+    if (ref $self and $argname){
+        if (eval { $self->can($argname) } ) {
+            eval { $db_arg = $self->can($argname)->($self) };
+        } else {
+            $db_arg = $self->{$argname};
+        }
+    }
     $db_arg = $args->{args}->{$argname} if exists $args->{args}->{$argname};
     $db_arg = $db_arg->to_db if eval {$db_arg->can('to_db')};
     $db_arg = { type => 'bytea', value => $db_arg} if $_->{type} eq 'bytea';

--- a/lib/PGObject/Simple.pm
+++ b/lib/PGObject/Simple.pm
@@ -174,7 +174,7 @@ Returns the database handle for the object.
 
 sub dbh {
     my ($self) = @_;
-    return $self->{_dbh};
+    return ($self->{_dbh} or $self->{_DBH});
 }
 
 =head2 associate($pgobject)
@@ -272,7 +272,7 @@ sub call_dbmethod {
     my %args = @_;
     croak 'No function name provided' unless $args{funcname};
     if (eval { $self->isa(__PACKAGE__) } and ref $self){
-        $args{dbh} = $self->{_dbh} if $self->{_dbh} and !$args{dbh};
+        $args{dbh} = $self->dbh if $self->dbh and !$args{dbh};
 
         $args{funcprefix} //= $self->{_func_prefix};
         $args{funcschema} //= $self->{_func_schema};

--- a/lib/PGObject/Simple.pm
+++ b/lib/PGObject/Simple.pm
@@ -152,6 +152,7 @@ sub new {
     $ref->_set_funcprefix($ref->{_funcprefix});
     $ref->_set_funcschema($ref->{_funcschema});
     $ref->_set_registry($ref->{_registry});
+    $ref->associate($self) if ref $self;
     return $ref;
 }
 

--- a/t/01-constructor.t
+++ b/t/01-constructor.t
@@ -1,5 +1,5 @@
 use PGObject::Simple;
-use Test::More tests => 3;
+use Test::More tests => 5;
 use DBI;
 
 my %hash = (
@@ -16,5 +16,10 @@ my $obj = PGObject::Simple->new(%hash);
 ok($obj->isa('PGObject::Simple'), 'Object successfully created');
 
 is($obj->set_dbh($dbh), $dbh, 'Set database handle successfully');
-is($dbh, $obj->{_DBH}, "database handle cross check");
+is($dbh, $obj->dbh, "database handle cross check");
+
+my $obj2 = PGObject::Simple->new(%hash);
+is($obj2->dbh, undef, 'No db handle for second object');
+$obj2->associate($obj);
+is($dbh, $obj2->dbh, "database handle cross check after association");
 

--- a/t/02-call_procedure.t
+++ b/t/02-call_procedure.t
@@ -1,6 +1,7 @@
 use PGObject::Simple;
 use Test::More;
 use DBI;
+use Data::Dumper;
 
 my %hash = (
    foo => 'foo',
@@ -42,14 +43,14 @@ SKIP: {
       funcname => 'foobar',
       args => ['text', 'text2', '5', '30']
    );
-   is ($ref->{foobar}, 159, 'Correct value returned, call_procedure');
+   is ($ref->{foobar}, 159, 'Correct value returned, call_procedure') or diag Dumper($ref);
 
    ($ref) = PGObject::Simple->call_procedure(
       dbh => $dbh,
       funcname => 'foobar',
       args => ['text', 'text2', '5', '30']
    );
-   is ($ref->{foobar}, 159, 'Correct value returned, call_procedure, package invocation');
+   is ($ref->{foobar}, 159, 'Correct value returned, call_procedure, package invocation') or diag Dumper($ref);
 
 
    ($ref) = $obj->call_procedure(
@@ -58,19 +59,19 @@ SKIP: {
       args => ['text1', 'text2', '5', '30']
    );
 
-   is ($ref->{foobar}, 160, 'Correct value returned, call_procedure w/schema');
+   is ($ref->{foobar}, 160, 'Correct value returned, call_procedure w/schema') or diag Dumper($ref);
 
    ($ref) = $obj->call_dbmethod(
       funcname => 'foobar'
    );
 
-   is ($ref->{foobar}, $answer, 'Correct value returned, call_dbmethod');
+   is ($ref->{foobar}, $answer, 'Correct value returned, call_dbmethod') or diag Dumper($ref);
    ($ref) = PGObject::Simple->call_dbmethod(
       funcname => 'foobar',
           args => \%hash,
            dbh => $dbh,
    );
-   is ($ref->{foobar}, $answer, 'Correct value returned, call_dbmethod');
+   is ($ref->{foobar}, $answer, 'Correct value returned, call_dbmethodi with hash and no ref') or diag Dumper($ref);
        
 
    ($ref) = $obj->call_dbmethod(
@@ -78,19 +79,19 @@ SKIP: {
       args     => {id => 4}
    );
 
-   is ($ref->{foobar}, 14, 'Correct value returned, call_dbmethod w/args');
+   is ($ref->{foobar}, 14, 'Correct value returned, call_dbmethod w/args') or diag Dumper($ref);
    $obj->_set_funcprefix('foo');
    ($ref) = ($ref) = $obj->call_dbmethod(
       funcname => 'bar',
       args     => {id => 4}
    );
-   is ($ref->{foobar}, 14, 'Correct value returned, call_dbmethod w/args/prefix');
+   is ($ref->{foobar}, 14, 'Correct value returned, call_dbmethod w/args/prefix') or diag Dumper($ref);
    ($ref) = ($ref) = $obj->call_dbmethod(
       funcname => 'oobar',
       args     => {id => 4},
     funcprefix => 'f'
    );
-   is ($ref->{foobar}, 14, 'Correct value returned, call_dbmethod w/exp. pre.');
+   is ($ref->{foobar}, 14, 'Correct value returned, call_dbmethod w/exp. pre.') or diag Dumper($ref);
 
    $obj->_set_funcschema('test');
    $obj->_set_funcprefix('');
@@ -98,7 +99,7 @@ SKIP: {
       funcname => 'foobar'
    );
 
-   is ($ref->{foobar}, $answer * 2, 'Correct value returned, call_dbmethod');
+   is ($ref->{foobar}, $answer * 2, 'Correct value returned, call_dbmethod') or diag Dumper($ref);
 }
 
 $dbh->disconnect if $dbh;


### PR DESCRIPTION
2.001	2017-05-19
	Removed support for Perl 5.6 and 5.8
	Code cleanup
	Now provide exports for code re-use in rolls and adaptors
	Give precedence to functions over hash elements in object mappings.
	Added getters and setters for dbh
	Added association interface